### PR TITLE
Remove incorrect package glob from the manifest

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,2 @@
  packages:
-  - src/*
   - examples/*


### PR DESCRIPTION
This is invalid because u don't have any extra `package.json` files within `src`. This would be valid if u'd have some `src/*/package.json`

Extra context: the root workspace is always included anyway, see https://pnpm.io/pnpm-workspace_yaml :
> The root package is always included, even when custom location wildcards are used.

